### PR TITLE
bootswatch updated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "lodash": "^4.8.2",
     "ng-formio-helper": "^0.11.0",
     "ng-formio": "^1.6.7",
-    "bootswatch": "^3.3.6+1",
+    "bootswatch": "^3.3.6",
     "font-awesome": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
"bower install" was breaking because of the "+1". Works fine without and automatically downloads the "+1".
